### PR TITLE
Fix IE positioning.

### DIFF
--- a/tooltips.coffee
+++ b/tooltips.coffee
@@ -133,7 +133,7 @@ Template.tooltips.helpers
 
 	position: ->
 		css = getTooltip().css
-		return "position: absolute; top: #{css.top}px; left: #{css.left}px"
+		return "position: absolute; top: #{css.top}px; left: #{css.left}px;"
 
 	content: ->
 		getTooltip().text


### PR DESCRIPTION
IE sorts CSS attributes, and a missing trailing semicolon broke the styling.
