### PR TITLE
Fix moveElement arguments

### DIFF
--- a/tooltips.coffee
+++ b/tooltips.coffee
@@ -149,7 +149,7 @@ Template.tooltip.onRendered ->
 		insertElement: (node, next) ->
 			next.parentNode.insertBefore(node, next)
 
-		moveElement: (next) ->
+		moveElement: (node, next) ->
 			Tooltips.hide()
 			next.parentNode.insertBefore(node, next)
 


### PR DESCRIPTION
The arguments for the UIHook move do not match [the Blaze documentation](https://github.com/meteor/meteor/blob/master/History.md#blaze-6)
